### PR TITLE
docs: add development roadmap instructions to CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -119,6 +119,52 @@ git push -u origin feat/issue-11-margin-calculations
 - ✅ **Code must be formatted** - Run `pnpm format` before committing
 - ✅ **TypeScript must check** - Run `pnpm check` before committing
 
+## Development Roadmap
+
+### Overview
+
+The project is organized in 8 phases (Phase 0-8) to build Kassa incrementally with clear dependencies. **See `docs/ROADMAP.md`** for the complete checklist.
+
+### How to Work from the Roadmap
+
+1. **Check the roadmap** - `docs/ROADMAP.md` lists all issues in planned order
+2. **Pick next unchecked item** - Start with Phase 0 critical tasks
+3. **Go to GitHub** - All issue details are on GitHub (open the issue link)
+4. **Create a feature branch** - Use format: `<type>/<issue-number>-<slug>`
+   - Example: `feat/11-margin-calculations`
+5. **Work TDD** - Write tests first, then code (marked issues have explicit TDD guidance)
+6. **Commit with reference** - Always include `Closes #<issue-number>` in commit message
+7. **Push & Create PR** - Link PR to the issue, get review, merge
+8. **Check off in roadmap** - When PR is merged to main, update `docs/ROADMAP.md` to mark the item as complete: `- [x]` (in the same PR or immediately after)
+
+### Phase Guidelines
+
+- **Phase 0**: Setup & configuration (critical before Phase 1)
+- **Phase 1**: Core business logic & UI components
+- **Phase 2**: Client & order persistence with PouchDB
+- **Phase 3**: Sales history & analytics
+- **Phase 4**: Product management & settings
+- **Phase 5**: Offline sync & connectivity
+- **Phase 6**: Complete test coverage (parallel with Phases 1-3)
+- **Phase 7**: Polish, optimization, documentation
+- **Phase 8**: Deployment preparation
+
+### Critical Path (If Unsure Where to Start)
+
+1. Phase 0: Setup (0.1-0.6)
+2. Phase 1.1-1.2: TypeScript interfaces & calculations (TDD)
+3. Phase 1.3-1.6: Store & UI components
+4. Phase 1.7: Main layout
+5. Phase 2: Clients & order persistence
+6. Continue sequentially through phases
+
+### Key Points
+
+- **All issue details are on GitHub** - No separate design docs, refer to the GitHub issue directly
+- **TDD-marked issues** - Have explicit test requirements in the issue description
+- **Dependencies matter** - Don't skip phases or issues out of order (e.g., Phase 4 depends on Phase 2)
+- **Offline-first mindset** - All features must work without network access
+
 ---
 
 ## Quick Commands

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -1,7 +1,9 @@
 # 📋 Kassa Development Roadmap
 
-Quick checklist of all issues in planned order.  
-See detailed specs in `docs/tmp/github-issues-draft-en.md`
+Quick checklist of all issues in planned order.
+
+> 💡 **All issue details are on GitHub.** Click the issue link (e.g., `#4`) to see full requirements, acceptance criteria, and TDD specifications.
+> **⚠️ ALL WORK MUST USE TDD** - Tests first, then implementation.
 
 ---
 
@@ -78,11 +80,12 @@ See detailed specs in `docs/tmp/github-issues-draft-en.md`
 ## 📝 How to Use This
 
 1. Pick next unchecked item
-2. Open the GitHub issue (#GH-XX)
-3. Create branch: `<type>/<GH-number>-<slug>`
-4. Work on it
-5. Create PR
-6. ✅ Check the item when merged
+2. Open the GitHub issue (#XX) for full details
+3. Create branch: `<type>/<issue-number>-<slug>` (e.g., `feat/4-pouchdb-setup`)
+4. **Work TDD**: Write tests first (failures), then code (pass tests), then refactor
+5. Create PR and link to the issue
+6. Get review and merge to main
+7. ✅ Check the item in roadmap when merged (update this file with `- [x]`)
 
 ---
 


### PR DESCRIPTION
## Summary

Added comprehensive instructions for working with the development roadmap:

- **CLAUDE.md**: New "Development Roadmap" section explaining:
  - How to work from the roadmap checklist
  - Phase structure and their purposes
  - Critical path for getting started
  - Key points about dependencies and TDD
  
- **ROADMAP.md**: Cleaned up and clarified:
  - Removed stale reference to `docs/tmp/github-issues-draft-en.md`
  - Added clear message that all details are on GitHub issues
  - **Emphasized TDD mandate** - ALL WORK MUST USE TDD (tests first)
  - Updated "How to Use This" section with explicit steps
  - Clarified process for checking off completed items

## Why

- Developers now have clear guidance on how to navigate and work from the roadmap
- Stale documentation references are removed
- TDD requirement is explicit and cannot be missed
- Process is documented for updating roadmap as work completes